### PR TITLE
Add multi-region multi-account functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,10 @@ Module Input Variables
 - `peer_from_vpc_id` - the VPC ID of the initiating VPC.
 - `peer_to_vpc_id` - the VPC ID of the receiving VPC.
 - `peer_from_route_tables` - route tables of the initiating VPC to add routes to the receiving VPC for.
-- `peer_to_vpc_route_tables` - route tables of the receiving VPC to add routes to the initiating VPC for.
+- `peer_to_route_tables` - route tables of the receiving VPC to add routes to the initiating VPC for.
+- `peer_to_region` - The region of the VPC accepting the connection.
+- `peer_to_profile` - The AWS profile credentials to use to accept the peer connection.
+- `peer_to_credentials` - The location of the credentials file to use for accepting the connection.
 - `auto_accept` - specify whether or not this connection should automatically be accepted
 
 
@@ -36,6 +39,10 @@ module "vpc_peering" {
   
   peer_from_route_tables   = ["rtb-xyz12345", "rtb-xyz54321", "rtb-xyz99999"]
   peer_to_route_tables     = ["rtb-abcd1234", "rtb-abcd5678"]
+
+  peer_to_region            = "us-east-2"
+  peer_to_credentials       = "~/.aws/creds"
+  peer_to_profile           = "default"
 }
 ```
 

--- a/aws_route.tf
+++ b/aws_route.tf
@@ -6,12 +6,13 @@ resource "aws_route" "peer_from_to_peer_to" {
 
   route_table_id            = "${element(var.peer_from_route_tables, count.index)}"
   destination_cidr_block    = "${data.aws_vpc.peer_to_vpc.cidr_block}"
-  vpc_peering_connection_id = "${aws_vpc_peering_connection.peer_from_to_peer_to_vpc.id}"
+  vpc_peering_connection_id = "${aws_vpc_peering_connection.peer_from_vpc.id}"
 }
 resource "aws_route" "peer_to_to_peer_from" {
   count = "${length(var.peer_to_route_tables)}"
 
+  provider                  = "aws.peer"
   route_table_id            = "${element(var.peer_to_route_tables, count.index)}"
   destination_cidr_block    = "${data.aws_vpc.peer_from_vpc.cidr_block}"
-  vpc_peering_connection_id = "${aws_vpc_peering_connection.peer_from_to_peer_to_vpc.id}"
+  vpc_peering_connection_id = "${aws_vpc_peering_connection_accepter.peer_to_vpc.id}"
 }

--- a/aws_vpc_peering_connection.tf
+++ b/aws_vpc_peering_connection.tf
@@ -1,8 +1,21 @@
-resource "aws_vpc_peering_connection" "peer_from_to_peer_to_vpc" {
+resource "aws_vpc_peering_connection" "peer_from_vpc" {
   peer_vpc_id   = "${data.aws_vpc.peer_to_vpc.id}"
   vpc_id        = "${data.aws_vpc.peer_from_vpc.id}"
+  peer_region   = "${data.aws_region.peer.id}"
+  peer_owner_id = "${data.aws_caller_identity.peer.account_id}"
 
-  auto_accept = "${var.auto_accept}"
+  auto_accept = false
+
+  tags = {
+    Name    = "${var.peer_from_vpc_name} to ${var.peer_to_vpc_name}"
+    Comment = "Managed By Terraform"
+  }
+}
+
+resource "aws_vpc_peering_connection_accepter" "peer_to_vpc" {
+  provider                  = "aws.peer"
+  vpc_peering_connection_id = "${aws_vpc_peering_connection.peer_from_vpc.id}"
+  auto_accept               = "${var.auto_accept}"
 
   tags = {
     Name    = "${var.peer_from_vpc_name} to ${var.peer_to_vpc_name}"

--- a/data.tf
+++ b/data.tf
@@ -3,5 +3,6 @@ data "aws_vpc" "peer_from_vpc" {
 }
 
 data "aws_vpc" "peer_to_vpc" {
-  id = "${var.peer_to_vpc_id}"
+  provider = "aws.peer"
+  id       = "${var.peer_to_vpc_id}"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,7 @@
 output "peering_connection_id" {
-  value = "${aws_vpc_peering_connection.peer_from_to_peer_to_vpc.id}"
+  value = "${aws_vpc_peering_connection.peer_from_vpc.id}"
+}
+
+output "peering_acceptor_id" {
+  value = "${aws_vpc_peering_connection_accepter.peer_to_vpc.id}"
 }

--- a/provider.tf
+++ b/provider.tf
@@ -1,0 +1,15 @@
+provider "aws" {
+    alias   = "peer"
+    region  = "${var.peer_to_region}"
+    profile = "${var.peer_to_profile}"
+
+    shared_credentials_file = "${var.peer_to_credentials}"
+}
+
+data "aws_region" "peer" {
+  provider = "aws.peer"
+}
+
+data "aws_caller_identity" "peer" {
+  provider = "aws.peer"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -41,3 +41,23 @@ variable "auto_accept" {
 
   default = true
 }
+
+variable "peer_to_region" {
+  type = "string"
+
+  description = "The region of the vpc peering connection"
+}
+
+variable "peer_to_profile" {
+  type = "string"
+
+  description = "Profile to use for the peering conneciton"
+
+  default = "default"
+}
+
+variable "peer_to_credentials" {
+  type = "string"
+
+  description = "location of credentials file"
+}


### PR DESCRIPTION
Resolving Issue #2 AWS Supports Multi-Region Peering

Added Terraform functionality to create peering connections between multiple regions and/or multiple accounts. This required the addition of the `aws_vpc_peering_connection_accepter` resource and an accompanying `provider` to create an alias that the connection can utilize. This prompted the need to pass in a profile and the location of the AWS credentials file otherwise the provider will not work and the accepting VPC cannot be found. 

Updated the README.md to reflect these changes. 